### PR TITLE
Add inflate.c to fix a runtime error with oeminst

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -181,6 +181,7 @@ average_LDADD = $(SPECTRO_LDADD)
 oeminst_SOURCES =			\
 	../spectro/LzmaDec.h		\
 	../spectro/LzmaTypes.h		\
+	../spectro/inflate.c		\
 	../spectro/oemarch.c		\
 	../spectro/oemarch.h		\
 	../spectro/oeminst.c		\


### PR DESCRIPTION
Fixes inflate of 'disk1.cab' failed at i_ix 0x2, o_ix 0x0 error
when running oeminst -v i1ProfilerSetup.exe