### PR TITLE
Also build illumread

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -145,7 +145,7 @@ SPECTRO_LDADD =    	\
 
 
 bin_PROGRAMS += synthcal dispwin dispread dispcal fakeread synthread	\
-	chartread spotread spec2cie average oeminst ccxxmake
+	chartread illumread spotread spec2cie average oeminst ccxxmake
 
 synthcal_SOURCES = ../spectro/synthcal.c
 synthcal_LDADD = $(SPECTRO_LDADD)
@@ -168,6 +168,9 @@ synthread_LDADD = $(SPECTRO_LDADD)
 
 chartread_SOURCES = ../spectro/chartread.c
 chartread_LDADD = $(SPECTRO_LDADD)
+
+illumread_SOURCES = ../spectro/illumread.c
+illumread_LDADD = $(SPECTRO_LDADD)
 
 spotread_SOURCES = ../spectro/spotread.c
 spotread_LDADD = $(SPECTRO_LDADD)


### PR DESCRIPTION
I'm not entirely sure if it's the right place where I added it, but since all other *read.c stuff was there I hope I got it right. It adds the missing illumread tool:

$ illumread
Measure an illuminant, Version 1.6.3
Author: Graeme W. Gill, licensed under the AGPL Version 3
usage: illumread [-options] output.sp
 -v                   Verbose mode
 -S                   Plot spectrum for each reading
 -c listno            Choose instrument from the following list (default 1)
    ** No ports found **
 -N                   Disable initial calibration of instrument if possible
 -H                   Use high resolution spectrum mode (if available)
 -Y r                 Set refresh measurement mode
 -Y R:rate            Override measured refresh rate with rate Hz
 -W n|h|x             Override serial port flow control: n = none, h = HW, x = Xon/Xoff
 -D [level]           Print debug diagnostics to stderr
 illuminant.sp        File to save measurement to

However I also didn't actually test it besides just running the command like stated above, nor do I know what it actually does. I just noticed it is currently missing.